### PR TITLE
Prefer __fzfcmd over fzf command

### DIFF
--- a/fzf-z.plugin.zsh
+++ b/fzf-z.plugin.zsh
@@ -5,7 +5,7 @@
 
 __fzfz() {
   local cmd="z -l | awk '{print \$2}'"
-  eval "$cmd" | fzf -m | while read item; do
+  eval "$cmd" | $(__fzfcmd) -m | while read item; do
     printf '%q ' "$item"
   done
   echo


### PR DESCRIPTION
fix: we should check if the function is available or fallback to fzf